### PR TITLE
ibverbs-tests: Fix buffer overrun of multiple work completions

### DIFF
--- a/tests/cross-channel/cc_verbs_test.h
+++ b/tests/cross-channel/cc_verbs_test.h
@@ -549,7 +549,7 @@ protected:
 		gettimeofday(&cur_time, NULL);
 		start_time_msec = (cur_time.tv_sec * 1000) + (cur_time.tv_usec / 1000);
 		do {
-			poll_result = ibv_poll_cq(cq, 0x10, wc);
+			poll_result = ibv_poll_cq(cq, num_entries, &wc[poll_cq_count]);
 			ASSERT_TRUE(poll_result >= 0 );
 			poll_cq_count += poll_result;
 

--- a/tests/cross-channel/create_cq.cc
+++ b/tests/cross-channel/create_cq.cc
@@ -95,9 +95,13 @@ TEST_F(tc_verbs_create_cq, ti_1) {
 	__poll_cq(ctx->scq, ctx->cq_tx_depth + 2, ctx->wc, wrid - 1);
 	EXPECT_EQ(IBV_WC_SUCCESS, ctx->wc[wrid - 2].status);
 	EXPECT_EQ((uint64_t)(wrid - 2), ctx->wc[wrid - 2].wr_id);
-
+#if 0
+	/*
+	 * It is closed, because there is no way to limit the number of
+	 * CQE per CQ
+	 */
 	__poll_cq(ctx->rcq, ctx->cq_rx_depth + 2, ctx->wc, wrid - 1);
-
+#endif
 	/* Check result */
 	{
 		struct ibv_async_event event;


### PR DESCRIPTION
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>